### PR TITLE
Speed improvement when sending large buffers via CBOR

### DIFF
--- a/dist/holoplaycore.js
+++ b/dist/holoplaycore.js
@@ -73,8 +73,8 @@
 	  }
 	  function writeUint8Array(value) {
 	    var dataView = ensureSpace(value.length);
-	    for (var i = 0; i < value.length; ++i)
-	      dataView.setUint8(offset + i, value[i]);
+	    const DataView8 = new Uint8Array(dataView.buffer);
+	    DataView8.set( value, offset );
 	    write();
 	  }
 	  function writeUint16(value) {


### PR DESCRIPTION
~230ms to ~21ms (using example 3mb quilts)

I guess it's possible that < 2048 (from previous work chrome seems to store typed array pages at 2kb) might be better with a for loop, than allocating a new view